### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/AhaAPI/user.py
+++ b/AhaAPI/user.py
@@ -18,8 +18,11 @@ class User:
         Initializes the User class
         :param id: the user id
         """
-        if os.path.exists(f"{USER_DB_PATH}{id}.json"):
-            with open(f"{USER_DB_PATH}{id}.json", "r") as json_file:
+        user_file_path = os.path.normpath(f"{USER_DB_PATH}{id}.json")
+        if not user_file_path.startswith(os.path.abspath(USER_DB_PATH)):
+            raise Exception("Invalid user ID")
+        if os.path.exists(user_file_path):
+            with open(user_file_path, "r") as json_file:
                 self.user_data = json.load(json_file)
         else:
             self.user_data = {
@@ -35,7 +38,10 @@ class User:
         Saves the user data
         :return:
         """
-        with open(f"{USER_DB_PATH}{self.user_data['id']}.json", "w") as json_file:
+        user_file_path = os.path.normpath(f"{USER_DB_PATH}{self.user_data['id']}.json")
+        if not user_file_path.startswith(os.path.abspath(USER_DB_PATH)):
+            raise Exception("Invalid user ID")
+        with open(user_file_path, "w") as json_file:
             json.dump(self.user_data, json_file)
 
     def __del__(self):


### PR DESCRIPTION
Potential fix for [https://github.com/xDazld/HacksGiving-2024/security/code-scanning/1](https://github.com/xDazld/HacksGiving-2024/security/code-scanning/1)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. We can achieve this by normalizing the path using `os.path.normpath` and then checking that the normalized path starts with the root folder. This will prevent any path traversal attacks.

1. Normalize the constructed file path using `os.path.normpath`.
2. Check that the normalized path starts with the root folder (`USER_DB_PATH`).
3. If the check fails, raise an exception or handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
